### PR TITLE
Update examples with LFM2Sloth branding

### DIFF
--- a/examples/experiment_tracking_demo.py
+++ b/examples/experiment_tracking_demo.py
@@ -2,7 +2,7 @@
 """
 Experiment Tracking Demo
 
-This script demonstrates how to use TalkyTalky's experiment tracking features
+This script demonstrates how to use LFM2Sloth's experiment tracking features
 with both Weights & Biases and TensorBoard.
 """
 
@@ -46,9 +46,9 @@ def demo_tensorboard_tracking():
         # TensorBoard tracking configuration
         tracking_provider="tensorboard",
         experiment_name="demo_tensorboard_experiment",
-        project_name="talkytalky-demos",
+        project_name="lfm2sloth-demos",
         tracking_tags=["demo", "tensorboard"],
-        tracking_notes="Demonstration of TensorBoard integration with TalkyTalky",
+        tracking_notes="Demonstration of TensorBoard integration with LFM2Sloth",
         log_model_artifacts=True,
     )
     
@@ -108,9 +108,9 @@ def demo_wandb_tracking():
         # W&B tracking configuration
         tracking_provider="wandb",
         experiment_name="demo_wandb_experiment",
-        project_name="talkytalky-demos",
+        project_name="lfm2sloth-demos",
         tracking_tags=["demo", "wandb"],
-        tracking_notes="Demonstration of W&B integration with TalkyTalky",
+        tracking_notes="Demonstration of W&B integration with LFM2Sloth",
         log_model_artifacts=True,
         wandb_api_key=wandb_key,  # Or omit to use environment variable
     )
@@ -157,7 +157,7 @@ def demo_both_tracking():
         # Combined tracking configuration
         tracking_provider="both",  # This enables both TensorBoard and W&B
         experiment_name="demo_combined_experiment",
-        project_name="talkytalky-demos",
+        project_name="lfm2sloth-demos",
         tracking_tags=["demo", "combined", "tensorboard", "wandb"],
         tracking_notes="Demonstration of combined TensorBoard + W&B integration",
         log_model_artifacts=True,
@@ -180,7 +180,7 @@ def demo_both_tracking():
 def main():
     """Run experiment tracking demonstrations"""
     
-    print("🧪 TalkyTalky Experiment Tracking Demonstrations")
+    print("🧪 LFM2Sloth Experiment Tracking Demonstrations")
     print("=" * 60)
     print()
     

--- a/examples/inference_demo.py
+++ b/examples/inference_demo.py
@@ -13,7 +13,7 @@ import time
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from talkytalky.evaluation import InferenceEngine, Evaluator
+from lfm2sloth.evaluation import InferenceEngine, Evaluator
 
 
 def demo_chat_interface(model_path: str):

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -13,10 +13,10 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from talkytalky.model import ModelConfig, LoRAConfig
-from talkytalky.training import TrainingConfig, Trainer
-from talkytalky.evaluation import InferenceEngine
-from talkytalky.data import FormatConverter
+from lfm2sloth.model import ModelConfig, LoRAConfig
+from lfm2sloth.training import TrainingConfig, Trainer
+from lfm2sloth.evaluation import InferenceEngine
+from lfm2sloth.data import FormatConverter
 
 
 def main():

--- a/examples/test_ultrachat_expert.py
+++ b/examples/test_ultrachat_expert.py
@@ -141,7 +141,7 @@ def train_ultrachat_expert():
         # Experiment tracking configuration
         tracking_provider="tensorboard",  # Options: "none", "wandb", "tensorboard", "both"
         experiment_name="ultrachat_conversational_assistant",
-        project_name="talkytalky-experiments",
+        project_name="lfm2sloth-experiments",
         tracking_tags=["ultrachat", "conversational", "assistant"],
         tracking_notes="Training conversational assistant with UltraChat 200k dataset",
         log_model_artifacts=True,


### PR DESCRIPTION
- Replace TalkyTalky references with LFM2Sloth in text content
- Update project names from talkytalky-demos to lfm2sloth-demos
- Fix remaining import statements in example files
- Complete branding consistency across all examples